### PR TITLE
Fix Deepling_Brute_Entity.java

### DIFF
--- a/src/main/java/com/github/L_Ender/cataclysm/entity/Deepling/Deepling_Brute_Entity.java
+++ b/src/main/java/com/github/L_Ender/cataclysm/entity/Deepling/Deepling_Brute_Entity.java
@@ -118,7 +118,7 @@ public class Deepling_Brute_Entity extends AbstractDeepling {
     }
 
     public boolean checkSpawnRules(LevelAccessor worldIn, MobSpawnType spawnReasonIn) {
-        return ModEntities.rollSpawn(CMCommonConfig.Spawning.DeeplingBruteSpawnWeight, this.getRandom(), spawnReasonIn);
+        return ModEntities.rollSpawn(CMCommonConfig.Spawning.DeeplingBruteSpawnRolls, this.getRandom(), spawnReasonIn);
     }
 
     @Nullable


### PR DESCRIPTION
Fixes Deepling Brute spawning using it's weight value instead of spawn rolls.

Mentioned by Teboran in the discord.